### PR TITLE
`graph` no longer valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker_client_config_location: "/root/.docker/config.json"
 
 # default dockerd configuration options ----------------------------------------
 ## https://docs.docker.com/engine/reference/commandline/dockerd/#/linux-configuration-file
-docker_config_graph: "/var/lib/docker"
+docker_config_data_root: "/var/lib/docker"
 docker_config_log_driver: ""
 docker_config_log_opts: {}
 docker_config_max_concurrent_downloads: 3
@@ -111,7 +111,7 @@ Advanced playbook with various variables applied
 - hosts: localhost
   vars:
     # store docker containers/images to /opt/docker
-    docker_config_graph: /opt/docker
+    docker_config_data_root: /opt/docker
     # change default docker bridge subnet
     docker_config_bip: 172.16.77.77/24
     # set default log driver to journald

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,7 @@ docker_client_config_location: "/root/.docker/config.json"
 ## https://github.com/docker/docker-ce-packaging/pull/132
 # docker_config_hosts:
 #   - "unix:///var/run/docker.sock"
-docker_config_graph: "/var/lib/docker"
+docker_config_data_root: "/var/lib/docker"
 docker_config_log_driver: ""
 docker_config_log_opts: {}
 docker_config_max_concurrent_downloads: 3
@@ -85,7 +85,7 @@ docker_config_insecure_registries: []
 docker_config_common:
   "log-driver": "{{ docker_config_log_driver }}"
   "log-opts": "{{ docker_config_log_opts }}"
-  "graph": "{{ docker_config_graph }}"
+  "data-root": "{{ docker_config_data_root }}"
   "max-concurrent-downloads": "{{ docker_config_max_concurrent_downloads }}"
   "max-concurrent-uploads": "{{ docker_config_max_concurrent_uploads }}"
   "debug": "{{ docker_config_debug }}"


### PR DESCRIPTION
replaced with `data-root` in latest release

https://github.com/moby/moby/releases/tag/v23.0.0

```
Remove the -g and --graph daemon options in favor of --data-root. docker/cli#3739

    These options have been hidden and deprecated since 17.05.
    Deprecation notice
```
